### PR TITLE
* No apparent reason why this is needed. Messes with ContextMenus by …

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -447,11 +447,11 @@ namespace Hardcodet.Wpf.TaskbarNotification
                     singleClickTimer.Change(DoubleClickWaitTime, Timeout.Infinite);
                     isLeftClickCommandInvoked = true;
                 }
-                else
-                {
-                    // show context menu immediately
-                    ShowContextMenu(cursorPosition);
-                }
+                //else
+                //{
+                //    // show context menu immediately
+                //    ShowContextMenu(cursorPosition);
+                //}
             }
 
             // make sure the left click command is invoked on mouse clicks


### PR DESCRIPTION
…raising firing the same message twice. Commenting this out, context message fires just once as intended.